### PR TITLE
Fix Docusaurus Layout imports for custom pages

### DIFF
--- a/docs/docusaurus/src/pages/data-models.mdx
+++ b/docs/docusaurus/src/pages/data-models.mdx
@@ -3,6 +3,7 @@ title: Data Models & Database Schema
 description: Database schema and data models for Uptime Watcher
 ---
 /* eslint-disable no-unused-vars -- JSX imports used in components */
+import Layout from '@theme/Layout';
 import Mermaid from '@theme/Mermaid';
 
 export default function DataModels() {

--- a/docs/docusaurus/src/pages/deployment-infrastructure.mdx
+++ b/docs/docusaurus/src/pages/deployment-infrastructure.mdx
@@ -3,6 +3,7 @@ title: Deployment & Infrastructure
 description: Deployment architecture and infrastructure diagrams for Uptime Watcher
 ---
 /* eslint-disable no-unused-vars -- JSX imports used in components */
+import Layout from '@theme/Layout';
 import Mermaid from '@theme/Mermaid';
 
 export default function DeploymentInfrastructure() {

--- a/docs/docusaurus/src/pages/monitoring-workflows.mdx
+++ b/docs/docusaurus/src/pages/monitoring-workflows.mdx
@@ -3,6 +3,7 @@ title: Monitoring Workflows
 description: Detailed monitoring workflows and processes for Uptime Watcher
 ---
 /* eslint-disable no-unused-vars -- JSX imports used in components */
+import Layout from '@theme/Layout';
 import Mermaid from '@theme/Mermaid';
 
 export default function MonitoringWorkflows() {

--- a/docs/docusaurus/src/pages/performance-metrics.mdx
+++ b/docs/docusaurus/src/pages/performance-metrics.mdx
@@ -3,6 +3,7 @@ title: Performance Metrics Overview
 description: Performance analysis and optimization strategies for Uptime Watcher
 ---
 /* eslint-disable no-unused-vars -- JSX imports used in components */
+import Layout from '@theme/Layout';
 import Mermaid from '@theme/Mermaid';
 
 export default function PerformanceMetrics() {

--- a/docs/docusaurus/src/pages/system-architecture.mdx
+++ b/docs/docusaurus/src/pages/system-architecture.mdx
@@ -3,6 +3,7 @@ title: System Architecture Overview
 description: Comprehensive system architecture and component relationships
 ---
 /* eslint-disable no-unused-vars -- Import in JSX */
+import Layout from '@theme/Layout';
 import Mermaid from '@theme/Mermaid';
 
 export default function SystemArchitecture() {


### PR DESCRIPTION
## Summary
- import the Docusaurus `Layout` component in each custom Mermaid page so static generation can resolve the layout.

## Testing
- npm --prefix docs/docusaurus run build *(fails: `docusaurus` executable missing because docs dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d992c011bc8330aa451ac72bf0f84c